### PR TITLE
Correct module path in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   },
   "name": "styled-griddie",
   "author": "Ed Stephens",
-  "module": "dist/griddie.esm.js",
+  "module": "dist/styled-griddie.esm.js",
   "devDependencies": {
     "@testing-library/react": "^10.2.1",
     "@types/react-test-renderer": "^16.9.2",


### PR DESCRIPTION
When installed, the styled-griddie package provides a `styled-griddie.esm.js` file, not a `griddie.esm.js` file. This corrects the path so that ESM-aware bundlers are able to find the right file to build.